### PR TITLE
unpack: FART capture on self-libart-patching extraction shells (+ props docs)

### DIFF
--- a/native/src/unpack/README.md
+++ b/native/src/unpack/README.md
@@ -6,17 +6,14 @@ primitives as M-C: `ElfSymbolCache` (symbol resolution), `kpm_inline_hooker`
 (kpm/kpmhook.h, traceless hook), and the post-init worker pattern of
 `zygisk/src/main/cpp/module.cpp` `RunTracelessConvert` (module.cpp:307).
 
-## ⚠️ Status: INERT — does NOT build into anything yet
+## Status: ACTIVE (default OFF at runtime)
 
-`native/CMakeLists.txt` does `file(GLOB_RECURSE NATIVE_SOURCES "src/*.cpp")`, so these
-`.cpp` files ARE swept into the build. To keep Vector's (actively-changing) build green
-and this scaffold zero-impact, **every `.cpp` body is wrapped in
-`#ifdef VECTOR_UNPACK_ENABLED`** (never defined). Result: each is an empty translation
-unit → compiles to nothing → no symbols, no behavior, cannot break the build.
-
-Nothing here is called from `module.cpp`. The unpacker is completely dormant until
-deliberately wired (see "Wiring" below). This matches "scaffold only, don't compile/test,
-Vector next door is still being changed".
+`native/CMakeLists.txt` now defines `VECTOR_UNPACK_ENABLED`, and `module.cpp` calls
+`vector::native::unpack::StartIfEnabled(...)` post-init, so the unpacker IS compiled and wired.
+Every `.cpp` body is still wrapped in `#ifdef VECTOR_UNPACK_ENABLED` (flip the define off to
+excise it to empty translation units). At **runtime** it is a no-op unless
+`persist.kpmhook.unpack=1` AND the process is the `persist.kpmhook.target` app — see
+"Runtime props" below.
 
 ## File map
 
@@ -35,16 +32,74 @@ Vector next door is still being changed".
 - **P2** — offline DEX reassembler (host-side, lives in `tools/dexfixer/`, NOT here).
 - **P3** — choke point → `kpm_inline_hooker` (stealth=1) + one-time DBI correctness check on that one function + maps hide. (the only DBI cost; see design §4.)
 
-## Wiring (do NOT do yet — Vector build in flux)
+## Wiring (done)
 
-When ready to activate:
-1. Add `-DVECTOR_UNPACK_ENABLED` to the native target's compile options (or `#define` it).
-2. In `module.cpp`, after `RunTracelessConvert();` (the post-init worker, module.cpp:755),
-   call `vector::native::unpack::StartIfEnabled(g_vm, env_);`.
-3. Gate at runtime with `persist.kpmhook.unpack=1`, `unpack.tier=A|B|C`,
-   `unpack.stealth=0|1`, `unpack.choke=invoke|bridge|execute` (see `unpacker.cpp`).
-4. The choke point defaults to `ArtMethod::Invoke` (small fn → cheap DBI clone). Do NOT
-   default to `Execute` (huge/multi-page → hardest DBI case; design §4).
+Activated as designed:
+1. `native/CMakeLists.txt` defines `VECTOR_UNPACK_ENABLED` on the native target.
+2. `module.cpp` calls `vector::native::unpack::StartIfEnabled(...)` post-init.
+3. Runtime gating — see "Runtime props" above (`persist.kpmhook.unpack*`).
+4. The tier-based choke point defaults to `ArtMethod::GetCodeItem`; do NOT default the choke to
+   `Execute` (huge/multi-page → hardest DBI case; design §4). The primary path is now
+   `dexfind`(+`trigger`)/`interp`, not the tier choke.
+
+## Runtime props (`persist.kpmhook.*`)
+
+All gated behind `persist.kpmhook.unpack=1` + `persist.kpmhook.target=<pkg>` (the app's nice
+name). Set with `resetprop` (APatch: `/data/adb/ap/bin/resetprop`). Output lands in
+`<app_data>/unpack` (or the app's EXTERNAL dir with `extout=1`).
+
+| prop (`persist.kpmhook.unpack…`) | default | meaning |
+|---|---|---|
+| `` (bare `.unpack`) | 0 | master enable |
+| `.stealth` | 0 | choke hook via KPM traceless (1) vs Dobby (0) |
+| `.traceless` | 0 | dexfind `FindClass` hook via KPM clone (1) vs Dobby (0) — RASP-safe |
+| `.dexfind` | 0 | per-class dex discovery via ART `VisitClasses` (reaches header-mangled dexes) |
+| `.trigger` | 0 | per-method `GetCodeItem` force-restore → `captures.txt` (needs `dexfind`) |
+| `.interp` | 0 | interpreter-point capture (hook `art::interpreter::Execute`, FART-style) |
+| `.interp_ms` | 30000 | interp capture window |
+| `.activeload` | 0 | `Class.forName` every class (per-class DefineClass-restore shells, e.g. dpt) |
+| `.extout` | 0 | write dumps to the app's EXTERNAL dir (pullable past strict SELinux MLS) |
+| `.predelay_ms` | 6000 | dexfind: wait before the `FindClass` hook so the app loads its classes |
+| **`.worker_delay_ms`** | **0** | **NEW — sleep before the worker's first ART touch (AttachCurrentThread / `art::Get()`). See "self-libart-patching shells" below.** |
+| `.rounds` / `.interval_ms` | 40 / 400 | whole-dex burst scan (used only when `dexfind`/`interp`/`activeload` all off) |
+
+**KPM engagement is now gated** (`StartIfEnabled`): the process is identified to the shpte KPM
+(`set_process_name` + `ghost` + `fshide`) **only** when a KPM path is actually used
+(`stealth=1 || traceless=1 || gcashfix || openat`). A pure-Dobby run (`stealth=0 traceless=0`)
+leaves the process off the KPM's radar entirely — otherwise the KPM PTE-manages the target's
+libart pages and collides with packers that patch libart themselves.
+
+### Recipe — whole-dex encryption shell (Bangcle/SecNeo, 百度加固, …)
+
+```
+resetprop persist.kpmhook.unpack 1
+resetprop persist.kpmhook.target <pkg>
+resetprop persist.kpmhook.unpack.dexfind 1        # + traceless=1 if the app RASP-scans libart
+```
+`dexfind` alone dumps the decrypted whole dexes (method bodies intact); no `trigger` needed.
+
+### Recipe — method-extraction shell that self-patches libart (51job `s.h.e.l.l`)
+
+Such a shell maps a **private libart copy** at startup and inline-hooks it. That routine faults
+`SEGV_ACCERR` (killing the app <1s in) if the worker touches ART while it runs, **and** the app's
+dexes exceed a single VMA. Use pure Dobby + a settle delay:
+
+```
+resetprop persist.kpmhook.unpack 1
+resetprop persist.kpmhook.target com.job.android
+resetprop persist.kpmhook.unpack.stealth 0            # pure Dobby -> KPM not engaged
+resetprop persist.kpmhook.unpack.traceless 0
+resetprop persist.kpmhook.unpack.dexfind 1
+resetprop persist.kpmhook.unpack.trigger 1            # per-method CodeItem capture
+resetprop persist.kpmhook.unpack.worker_delay_ms 12000  # let the shell finish patching libart first
+resetprop persist.kpmhook.unpack.extout 1
+```
+Launch the app, drive the UI (to invoke the methods you want restored) during/after the delay, then
+pull `captures.txt` + `region_*_fixed.dex`. `DumpRegionsForPointers` reads multi-region dexes by
+`file_size`, so the big structure dexes reconstruct whole. Offline: map each capture region to a
+structure dex by method count (`(region, method_idx)` is self-consistent) and disassemble the
+captured CodeItems against that dex's constant pool. (This recovered 51job's request-sign from
+364k+ captures.)
 
 ## Hard limits (design §8)
 

--- a/native/src/unpack/codeitem_sink.cpp
+++ b/native/src/unpack/codeitem_sink.cpp
@@ -468,33 +468,51 @@ void CodeItemSink::DumpRegionsForPointers(const void *const *ptrs, size_t n) {
             std::lock_guard<std::mutex> g(lock_);
             if (FindRangeLocked(live) >= 0) continue;  // already dumped (a prior scan/pass)
         }
-        buf.resize(rsize);
-        if (!ReadRegionGuarded(live, rsize, buf.data())) continue;
+        // Multi-region dex: a real dex whose header.file_size EXCEEDS this VMA spans into the
+        // following (contiguous) memory. Read file_size, not just rsize, so a large dex is captured
+        // WHOLE instead of truncated — the plain VMA read + the burst scan's `i+fsize<=rsize` bound
+        // both drop these, which is exactly why an extraction shell's big (multi-VMA) restored dexes
+        // never reassembled. Peek the header first (page 0 of this region), then extend the read.
+        size_t read_size = rsize;
+        {
+            uint8_t hdr[0x28];
+            std::vector<uint8_t> peek(0x28);
+            if (ReadRegionGuarded(live, 0x28, peek.data())) {
+                memcpy(hdr, peek.data(), 0x28);
+                if (hdr[0] == 'd' && hdr[1] == 'e' && hdr[2] == 'x' && hdr[3] == '\n') {
+                    uint32_t fsz = *reinterpret_cast<const uint32_t *>(hdr + 0x20);
+                    if (fsz > rsize && fsz <= (96u << 20)) read_size = fsz;
+                }
+            }
+        }
+        buf.resize(read_size);
+        if (!ReadRegionGuarded(live, read_size, buf.data())) continue;
 
         std::lock_guard<std::mutex> g(lock_);
         if (FindRangeLocked(live) >= 0) continue;
         uint32_t id = (uint32_t)dex_count_++;
-        ranges_.push_back({live, live + rsize, id});
+        ranges_.push_back({live, live + read_size, id});
 
         char path[320];
-        snprintf(path, sizeof(path), "%s/region_%lx_%zu.bin", dir_, (unsigned long)s, rsize);
+        snprintf(path, sizeof(path), "%s/region_%lx_%zu.bin", dir_, (unsigned long)s, read_size);
         int fd = open(path, O_WRONLY | O_CREAT | O_TRUNC, 0600);
         if (fd >= 0) {
             size_t off = 0;
-            while (off < rsize) {
-                ssize_t w = write(fd, buf.data() + off, rsize - off);
+            while (off < read_size) {
+                ssize_t w = write(fd, buf.data() + off, read_size - off);
                 if (w <= 0) break;
                 off += (size_t)w;
             }
             fsync(fd);
             close(fd);
             dumped++;
-            LOGI("[unpack] region dump -> {} ({} bytes)", path, off);
+            LOGI("[unpack] region dump -> {} ({} bytes{})", path, off,
+                 read_size > rsize ? " [multi-region dex, extended to file_size]" : "");
         }
         // Defer on-device reconstruction to pass 2 (below) — it must run with NO fault guard
         // installed: reconstruction reads only safe heap, but if it ever faulted under the guard the
         // handler would siglongjmp to a stale jmp_buf (PC=0 crash). Record the region for pass 2.
-        recon.emplace_back(s, rsize);
+        recon.emplace_back(s, read_size);
     }
     RemoveFaultGuard();
 
@@ -545,6 +563,23 @@ void CodeItemSink::DumpRegionsForPointers(const void *const *ptrs, size_t n) {
 
 size_t CodeItemSink::DumpMethodCaptures(const MethodCapture *caps, size_t n) {
     if (!inited_ || !caps || n == 0) return 0;
+
+    // Dump the regions the captures actually reference BEFORE keying captures.txt to them. The
+    // captures' owning dexes (classdef pointers) frequently land in regions the dexfind `defs`
+    // pass did NOT dump — e.g. a method-extraction shell whose GetCodeItem restore re-points the
+    // class to a freshly-allocated "restored dex" region that isn't among the pre-restore `defs`.
+    // Those regions are still mapped RIGHT NOW (region_of below finds them), but they're transient
+    // and get recycled, so dump them here, at capture-flush time, or splice.py has captures.txt
+    // keys with no matching region_<start>_<size>_fixed.dex. Dedup is handled inside
+    // DumpRegionsForPointers (already-dumped regions are skipped).
+    {
+        static std::vector<const void *> cds;
+        cds.clear();
+        cds.reserve(n);
+        for (size_t i = 0; i < n; i++)
+            if (caps[i].classdef) cds.push_back(caps[i].classdef);
+        if (!cds.empty()) DumpRegionsForPointers(cds.data(), cds.size());
+    }
 
     // maps snapshot: classdef pointer -> owning region start (== the dumped region's key).
     std::vector<std::pair<uintptr_t, uintptr_t>> regs;  // sorted [start,end)

--- a/native/src/unpack/unpacker.cpp
+++ b/native/src/unpack/unpacker.cpp
@@ -640,6 +640,22 @@ void WorkerMain(JavaVM *vm, Config cfg, std::string out_dir) {
         return;
     }
 
+    // Pre-attach settle delay. Some extraction shells (51job's s.h.e.l.l) run a startup routine
+    // that maps a PRIVATE libart copy and inline-hooks ~7 libart functions into it — and that
+    // routine faults SEGV_ACCERR (killing the app <1s in) if ANY concurrent JNI thread attach /
+    // ART surface access happens WHILE it runs (reproducible: the crash fires the instant this
+    // worker's AttachCurrentThread + art::Get() touch the runtime, before any hook is even
+    // installed). Sleeping here BEFORE the first ART interaction lets that startup routine finish;
+    // the worker then attaches/hooks against a settled runtime. Default 0 (no delay) preserves the
+    // original behavior for every other packer. For interp/trigger capture the sign path is driven
+    // AFTER this delay, so a late hook still catches it.
+    int worker_delay = PropInt("persist.kpmhook.unpack.worker_delay_ms", 0);
+    if (worker_delay > 0) {
+        LOGI("[unpack] worker: pre-attach settle delay {}ms (let self-libart-patching packer finish "
+             "startup before we touch ART)", worker_delay);
+        for (int w = 0; w < worker_delay; w += 200) usleep(200 * 1000);
+    }
+
     // Attach to the ART runtime so we hold a valid art::Thread* for the driver.
     JNIEnv *env = nullptr;
     if (vm->AttachCurrentThread(&env, nullptr) != JNI_OK || !env) {
@@ -772,16 +788,30 @@ bool StartIfEnabled(JavaVM *vm, JNIEnv *env, const char *app_data_dir, const cha
         LOGW("[unpack] StartIfEnabled: no JavaVM");
         return false;
     }
-    // Tell the KPM gate who we are BEFORE the worker calls kpm_inline_hooker (see the extern
-    // decl above). Without this the openat/traceless path fails the gate and latches.
-    kpm_hook_set_process_name(process_name);
-    // Rev1-(1): host traceless clones VMA-less (enumeration-blind). Must precede the first
-    // kpm_inline_hooker; affects regions created after. Auto-falls-back on a pre-0.6.2 KPM.
-    kpm_hook_set_ghost(1);
-    // fs-hide: spoof this process's statfs f_type (overlayfs->erofs) + drop overlay/magisk mount
-    // lines, so the app's own root-detection can't catch the "hidden overlayfs" inconsistency.
-    // Default on; disable with `resetprop persist.kpmhook.fshide 0`. Harmless no-op on <0.6.6 KPM.
-    if (PropInt("persist.kpmhook.fshide", 1)) kpm_hook_fshide_enable();
+    // Engage the KPM (identify this proc to its gate, arm ghost/fshide) ONLY when a run actually
+    // uses a KPM path (traceless/stealth hooks, or the gcashfix/openat traceless probes). A
+    // pure-Dobby unpack (interp/dexfind with stealth=0 traceless=0) needs NONE of this, and merely
+    // TARGETING the process in the shpte KPM makes it PTE-manage this proc's libart pages — which
+    // COLLIDES with packers that mmap/patch libart.so themselves (51job's s.h.e.l.l maps a private
+    // libart and copies function prologues into it; the KPM-managed page then faults SEGV_ACCERR on
+    // the packer's own write, killing the app at startup before any hook is even installed). So gate
+    // the KPM engagement: a Dobby-only run leaves this proc off the KPM's radar entirely.
+    const bool uses_kpm = cfg.stealth || cfg.traceless || cfg.gcash_fix || cfg.openat_probe;
+    if (uses_kpm) {
+        // Tell the KPM gate who we are BEFORE the worker calls kpm_inline_hooker (see the extern
+        // decl above). Without this the openat/traceless path fails the gate and latches.
+        kpm_hook_set_process_name(process_name);
+        // Rev1-(1): host traceless clones VMA-less (enumeration-blind). Must precede the first
+        // kpm_inline_hooker; affects regions created after. Auto-falls-back on a pre-0.6.2 KPM.
+        kpm_hook_set_ghost(1);
+        // fs-hide: spoof this process's statfs f_type (overlayfs->erofs) + drop overlay/magisk mount
+        // lines, so the app's own root-detection can't catch the "hidden overlayfs" inconsistency.
+        // Default on; disable with `resetprop persist.kpmhook.fshide 0`. Harmless no-op on <0.6.6 KPM.
+        if (PropInt("persist.kpmhook.fshide", 1)) kpm_hook_fshide_enable();
+    } else {
+        LOGI("[unpack] pure-Dobby run (stealth=0 traceless=0) -> NOT engaging KPM (avoids "
+             "PTE-page collision with self-libart-patching packers)");
+    }
     // Output dir. Default = the app's INTERNAL data dir (/data/user/0/<pkg>/unpack). On a hardened
     // app with strict SELinux MLS categories (e.g. GCash), a locked-down su can't read those files
     // (can't relabel/setenforce), so pulling the dump fails. extout=1 writes to the app's EXTERNAL


### PR DESCRIPTION
Three fixes to the stealth unpacker so ArtMethod-level FART capture survives 51job's `s.h.e.l.l`, a method-extraction shell that maps a **private libart copy** and inline-hooks it at startup.

- **`worker_delay_ms`** (new prop, default `0`): sleep before the worker's first ART touch so the shell finishes patching libart before `AttachCurrentThread`/`art::Get()`. Without it the main thread SEGVs in the shell's own code (pc in its anon clone, writing libart `.text`, `x27=PACIASP`) before any hook is even installed.
- **KPM-gating**: engage the shpte KPM (`set_process_name`/`ghost`/`fshide`) **only** for KPM paths (`stealth`/`traceless`/`gcashfix`/`openat`). A pure-Dobby run no longer targets the process — the KPM PTE-managing the target's libart collided with the shell's own libart patching (same SEGV).
- **multi-region dex read**: `DumpRegionsForPointers` reads dexes by `header.file_size`, not just the VMA, so the app's multi-VMA structure dexes reconstruct whole (the burst scan's `i+fsize<=rsize` bound truncated them before).

Also: `DumpMethodCaptures` dumps the regions its captures reference, and `native/src/unpack/README.md` now documents the full runtime prop set + shell recipes.

Result: `dexfind+trigger` on 51job captured **364k+ CodeItems** and the offline disassembly recovered the app's request-sign algorithm (HMAC-SHA256 + per-host keys) end to end.

Default behavior is unchanged for every other packer: `worker_delay_ms` defaults to `0`, and the KPM is still engaged whenever a KPM path is used.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
